### PR TITLE
don't auto-run babel on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "node.js"
   ],
   "scripts": {
-    "prepare": "babel node.js browser.js -d cjs",
     "test": "eslint '*.js' test && node --experimental-modules ./node_modules/.bin/ava"
   },
   "babel": {


### PR DESCRIPTION
babel is causing issues for Windows builds and is somewhat unnecessary since the transpiled versions are already in the repo.